### PR TITLE
Move over to worker-base to avoid size problems

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -11,7 +11,7 @@ RUN go get -u github.com/golang/dep/cmd/dep
 RUN dep ensure -vendor-only
 RUN go build -o app main.go
 
-FROM kindlyops/reporter:latest
+FROM kindlyops/reporter:worker-base
 ARG COMMIT=""
 
 LABEL commit=${COMMIT}

--- a/worker/docker-build/build-and-push.sh
+++ b/worker/docker-build/build-and-push.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e
-docker build -t kindlyops/reporter .
-docker push kindlyops/reporter:latest
+docker build -t kindlyops/reporter:worker-base .
+
+docker push kindlyops/reporter:worker-base

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   report:
-    image: havengrc-docker.jfrog.io/kindlyops/reporter:latest
+    image: havengrc-docker.jfrog.io/kindlyops/reporter:worker-base
     working_dir: /docs
     volumes:
       - .:/docs


### PR DESCRIPTION
This will eventually need to split into our own base image
for haven to allow the reporter toolchain to evolve
independently.
