### PR TITLE
Try to get the error snackbar working

### DIFF
--- a/webui/public/index.html
+++ b/webui/public/index.html
@@ -45,10 +45,5 @@
 </head>
 <body>
     <div id="elm"></div>
-
-    <div id="snackbar" class="snackbar">
-        <div id="snackbar-body" class="snackbar-body"></div>
-    </div>
-
 </body>
 </html>

--- a/webui/src/Main.elm
+++ b/webui/src/Main.elm
@@ -251,6 +251,9 @@ view model =
 
             Just user ->
                 insideView model user
+        , div [ id "snackbar", class "snackbar" ]
+            [ div [ id "snackbar-body", class "snackbar-body" ] []
+            ]
         ]
     }
 

--- a/webui/src/index.js
+++ b/webui/src/index.js
@@ -97,7 +97,7 @@ elmApp.ports.keycloakLogout.subscribe(function () {
 })
 
 elmApp.ports.showError.subscribe(function (messageString) {
-  console.error(messageString)
+  //console.error(messageString)
   let snackBarElement = document.getElementById('snackbar')
   snackBarElement.classList.add('show')
   let snackBarBodyElement = document.getElementById('snackbar-body')


### PR DESCRIPTION
This seems to work. 🤷‍♂️ 

It would be nicer to get rid of the JS port that is doing the class stuff for show/hide and move that into Elm.