### PR TITLE
Refactor to disable terms with magic link

### DIFF
--- a/keycloak-service-providers/magic-link/src/main/java/org/kindlyops/auth/magic/MagicLinkFormAuthenticator.java
+++ b/keycloak-service-providers/magic-link/src/main/java/org/kindlyops/auth/magic/MagicLinkFormAuthenticator.java
@@ -90,6 +90,7 @@ public class MagicLinkFormAuthenticator extends AbstractUsernameFormAuthenticato
             }
             if (requestKey != null) {
                 if (requestKey.equals(sessionKey)) {
+                    context.getUser().removeRequiredAction("terms_and_conditions");
                     context.success();
                 } else {
                     context.failure(AuthenticationFlowError.INVALID_CREDENTIALS);


### PR DESCRIPTION
Signed-off-by: Christopher Mundus <chris@kindlyops.com>

# Description

This will now disable the terms and conditions check when using the magic link.

## Discussion list or pending tasks

We will have to have to add a checkbox and appropriate wording for terms and conditions with the registration funnel.
