### PR TITLE
Configure remark-lint to be reasonable on Codacy

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,11 @@
+{
+    "plugins": [
+        "remark-lint",
+        "remark-preset-lint-recommended",
+        ["lint-list-item-indent", "mixed"],
+        ["lint-no-literal-urls", false]
+    ],
+    "settings": {
+        "no-html": false
+    }
+}


### PR DESCRIPTION
add configuration file for the markdown linting tool to reduce the markdown issues reported by Codacy.