### PR TITLE
work around keycloak redirects on internal network

### DIFF
--- a/gatekeeper/Caddyfile.tmpl
+++ b/gatekeeper/Caddyfile.tmpl
@@ -1,6 +1,8 @@
 :80
 
-proxy / {{ .Env.KEYCLOAK_INTERNAL }}
+proxy / {{ .Env.KEYCLOAK_INTERNAL }} {
+    header_upstream X-Forwarded-Proto https
+}
 
 log / stdout "{combined}"
 errors stdout

--- a/k8s/gatekeeper-deployment.yaml
+++ b/k8s/gatekeeper-deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - name: KEYCLOAK_INTERNAL
               value: "http://keycloak.haven-production.svc:8080"
             - name: DISCOVERY_URL
-              value: "https://staging.havengrc.com/auth/realms/havendev"
+              value: "http://staging.havengrc.com/auth/realms/havendev"
             - name: CLIENT_SECRET
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
internal openid discovery is redirecting to https.