### PR TITLE
security-filter is what sets X-Forwarded-Proto

### DIFF
--- a/gatekeeper/config/gatekeeper.tmpl
+++ b/gatekeeper/config/gatekeeper.tmpl
@@ -24,10 +24,14 @@ encryption-key: {{ .Env.GATEKEEPER_SESSION_KEY }}
 
 listen: 0.0.0.0:{{ .Env.GATEKEEPER_LISTEN_PORT }}
 
+{{if .Env.TLS_CERT }}
 tls-cert: {{ .Env.TLS_CERT }}
 tls-private-key: {{ .Env.TLS_PRIVATE_KEY }}
+enable-security-filter: true
+{{ end }}
 
-enable-security-filter: false
+
+
 enable-https-redirection: false
 upstream-url: {{ .Env.UPSTREAM_URL }}
 skip-upstream-tls-verify: true


### PR DESCRIPTION
This addresses the invalid_parameter: redirect_uri error from keycloak in production (because keycloak isn't seeing X-Forwarded-Proto, it's expecting the redirect_uri to be http, not https).