### PR TITLE
Survey polish

### DIFF
--- a/webui/src/Page/Survey.elm
+++ b/webui/src/Page/Survey.elm
@@ -1413,8 +1413,7 @@ viewSurveyBox : IpsativeAnswer -> Html Msg
 viewSurveyBox answer =
     div [ class "col-md-6 pt-5" ]
         [ div [ class "question-container" ]
-            [ p [ class "question-category" ] [ text answer.category ]
-            , p [ class "question-text" ] [ text answer.answer ]
+            [ p [ class "question-text" ] [ text answer.answer ]
             , div []
                 (List.map
                     (\group -> viewSurveyPointsGroup answer group)

--- a/webui/src/Visualization.elm
+++ b/webui/src/Visualization.elm
@@ -175,19 +175,7 @@ spec model =
                     , pMType Ordinal
                     , pScale
                         [ scDomain
-                            (doStrs
-                                [ "Org Values"
-                                , "Org Behaves"
-                                , "Definition"
-                                , "Information"
-                                , "Operations"
-                                , "Technology"
-                                , "People"
-                                , "Risk"
-                                , "Accountability"
-                                , "Performance"
-                                ]
-                            )
+                            (doStrs questionColumns)
                         ]
                     ]
 
@@ -202,7 +190,9 @@ spec model =
         , data []
         , bar [ maColor "#e86953" ]
         , columns columnCount
-        , enc [ ( "facet", Json.Encode.object [ ( "field", Json.Encode.string "category" ), ( "type", Json.Encode.string "ordinal" ) ] ) ]
+        , enc
+            [ ( "facet", Json.Encode.object [ ( "field", Json.Encode.string "category" ), ( "type", Json.Encode.string "ordinal" ), ( "sort", Json.Encode.list Json.Encode.string [ "Process", "Compliance", "Trust", "Autonomy" ] ) ] )
+            ]
         , config []
         ]
 


### PR DESCRIPTION
Don't show the answer categories during the survey to prevent biasing the responses, and specify the layout order for the facets/categories in the chart.