### PR TITLE
Fix for faulty error return

### DIFF
--- a/worker/main.go
+++ b/worker/main.go
@@ -115,8 +115,7 @@ func SaveSurvey(ctx worker.Context, args ...interface{}) error {
 	log.Printf("SQL Result found user: %v", registration)
 	handleError(err)
 	if len(registration) == 0 {
-		log.Printf("db.select: User already registered. %s", userEmail)
-		return err
+		return fmt.Errorf("user registration funnel not found yet for: %s try again later", userEmail)
 	}
 	// Get user id for registered user.
 	users, err := keycloak.GetUser(userEmail)


### PR DESCRIPTION
Faktory jobs require an error to be returned
if it is to retry the job. This portion was not
returning an error properly and not retrying.

Signed-off-by: Christopher Mundus <chris@kindlyops.com>
