### PR TITLE
Fix for posting to surveys all the time

### DIFF
--- a/webui/src/Page/Survey.elm
+++ b/webui/src/Page/Survey.elm
@@ -591,12 +591,20 @@ update msg model authModel =
 
                                 cmd =
                                     Ports.renderVega (havenSpecs model)
+
+                                -- Post right away if the user is logged in
+                                extraCmd =
+                                    if Authentication.isLoggedIn authModel then
+                                        postIpsativeResponse authModel survey
+
+                                    else
+                                        Cmd.none
                             in
                             ( newModel
                             , Cmd.batch
                                 [ storeSurvey newModel (getQuestionNumber newModel)
                                 , cmd
-                                , postIpsativeResponse authModel survey
+                                , extraCmd
                                 ]
                             )
 


### PR DESCRIPTION
There was a bug that was introduced earlier that causes there to be a post right away to surveys/ even if the user was not logged in.

Signed-off-by: Christopher Mundus <chris@kindlyops.com>
