### PR TITLE
Sticky question, better policy loading

### DIFF
--- a/webui/src/Main.elm
+++ b/webui/src/Main.elm
@@ -151,19 +151,22 @@ update msg model =
                     let
                         -- a few paths in our application are not part of the SPA
                         -- but are instead other mini apps mounted at the path.
-                        -- for things like keycloak (and in the future, unleash)
+                        -- for things like keycloak.
                         -- force a full browser page load even though it's a path
                         -- on the same domain.
+                        -- For Iubenda, we need a full page load to get the
+                        -- IUbenda javascript to load the embedded policies
                         isKeycloak =
                             String.startsWith "/auth" url.path
 
                         isGatekeeper =
                             String.startsWith "/oauth/" url.path
-                    in
-                    if isKeycloak then
-                        ( model, Nav.load (Url.toString url) )
 
-                    else if isGatekeeper then
+                        isIubenda =
+                            String.startsWith "/cookie" url.path
+                                || String.startsWith "/privacy" url.path
+                    in
+                    if isKeycloak || isGatekeeper || isIubenda then
                         ( model, Nav.load (Url.toString url) )
 
                     else

--- a/webui/src/Page/Survey.elm
+++ b/webui/src/Page/Survey.elm
@@ -1401,11 +1401,13 @@ viewIpsativeSurveyTitle survey =
         questionTitle =
             currentQuestion.title
     in
-    div [ class "col-md-4 d-flex flex-column" ]
+    div [ class "col-md-4 d-flex flex-column sticky-top bg-white" ]
         [ img [ class "img-fluid mb-5 pt-3", alt "Haven GRC Company Logo", attribute "data-rjs" "2", id "logo", src "/img/logo@2x.png", height 71, width 82 ] []
-        , h3 [] [ text questionTitle ]
-        , p [ class "", style "color" "#B1B1B1" ] [ text ("Q " ++ String.fromInt questionNumber ++ "/" ++ String.fromInt totalQuestions) ]
-        , div [ class "row" ] (viewPointsLeft currentQuestion.pointsLeft survey.pointsPerQuestion)
+        , div []
+            [ h3 [] [ text questionTitle ]
+            , p [ class "", style "color" "#B1B1B1" ] [ text ("Q " ++ String.fromInt questionNumber ++ "/" ++ String.fromInt totalQuestions) ]
+            , div [ class "row" ] (viewPointsLeft currentQuestion.pointsLeft survey.pointsPerQuestion)
+            ]
         ]
 
 


### PR DESCRIPTION
This makes the top part of the page sticky for the questions in the survey, that way when scrolling on mobile the question and the points remaining is always visible.