### PR TITLE
Fix HAV-297 crash when creating report.

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /home/havenuser
 
 COPY --from=builder /go/src/github.com/kindlyops/havengrc/worker/app .
 COPY --from=builder /go/src/github.com/kindlyops/havengrc/worker/compilereport /usr/local/bin/
+COPY --from=builder /go/src/github.com/kindlyops/havengrc/worker/compilereport .
 COPY --from=builder /go/src/github.com/kindlyops/havengrc/worker/presentation.Rmd .
 COPY --from=builder /go/src/github.com/kindlyops/havengrc/worker/template.pptx .
 COPY --from=builder /go/src/github.com/kindlyops/havengrc/worker/README.txt .


### PR DESCRIPTION
Fix crash when generating report zip (I introduced a bug when I added the `compilereport` script to the zip file)