### PR TITLE
Animated transitions between internal pages.

### DIFF
--- a/webui/elm.json
+++ b/webui/elm.json
@@ -26,6 +26,7 @@
             "elm-community/string-extra": "4.0.1",
             "elm-community/typed-svg": "5.0.1",
             "elm-explorations/markdown": "1.0.0",
+            "etaque/elm-transit": "7.0.5",
             "gampleman/elm-visualization": "2.0.1",
             "gicentre/elm-vega": "5.1.0",
             "gicentre/elm-vegalite": "1.12.0",

--- a/webui/src/Main.elm
+++ b/webui/src/Main.elm
@@ -179,7 +179,11 @@ update msg model =
                     else
                         let
                             ( newTransit, transitCmd ) =
-                                Transit.start TransitMsg (SetPage (Route.locFor url)) ( 500, 500 ) model.transit
+                                if url /= model.url then
+                                    Transit.start TransitMsg (SetPage (Route.locFor url)) ( 500, 500 ) model.transit
+
+                                else
+                                    ( model.transit, Cmd.none )
                         in
                         ( { model | transit = newTransit }, Cmd.batch [ Nav.pushUrl model.key (Url.toString url), transitCmd ] )
 


### PR DESCRIPTION
Survey screens are not yet animated because the
survey page view is implemented differently and
doesn't change the URL. Survey screens need to
be set up to pushState on the URL so that browser
history works (allowing people to go back and
change answer) and we can integrate transitions.

Demo here: https://www.loom.com/share/8117abccfd5146ce876f717a5bb09a88