### PR TITLE
Adds magiclink instructions to use same browswer

### DIFF
--- a/keycloak-service-providers/magic-link/src/main/java/org/kindlyops/auth/magic/MagicLinkFormAuthenticator.java
+++ b/keycloak-service-providers/magic-link/src/main/java/org/kindlyops/auth/magic/MagicLinkFormAuthenticator.java
@@ -66,7 +66,7 @@ public class MagicLinkFormAuthenticator extends AbstractUsernameFormAuthenticato
                     .toString();
         }
 
-        String body = "<a href=\"" + link + "\">Click to login</a>";
+        String body = "Please open the link using the same web browser that requested it.</br><a href=\"" + link + "\">Click here to login.</a>";
         try {
             context.getSession().getProvider(EmailSenderProvider.class).send(context.getRealm().getSmtpConfig(), user,
                     "Login link", null, body);

--- a/keycloak-service-providers/magic-link/src/main/resources/theme-resources/templates/view-email.ftl
+++ b/keycloak-service-providers/magic-link/src/main/resources/theme-resources/templates/view-email.ftl
@@ -6,7 +6,7 @@
         ${msg("loginTitleHtml",(realm.displayNameHtml!''))?no_esc}
     <#elseif section = "form">
         <#if realm.password>
-            An email has been sent.
+            An email has been sent. Please open the link using the same web browser.
         </#if>
     </#if>
 </@layout.registrationLayout>


### PR DESCRIPTION
We now inform the user to use the same browser
when generating a magiclink and remind them in
the email as well.

Signed-off-by: Christopher Mundus <chris@kindlyops.com>

post link creation:
![image](https://user-images.githubusercontent.com/17323411/61302584-074dc580-a7b4-11e9-917a-26da8c14635e.png)

email content:
![image](https://user-images.githubusercontent.com/17323411/61302601-116fc400-a7b4-11e9-9f3a-ea53d75d7fa7.png)
