### PR TITLE
Fix access token not refreshing automatically

### DIFF
--- a/gatekeeper/config/gatekeeper.tmpl
+++ b/gatekeeper/config/gatekeeper.tmpl
@@ -16,7 +16,7 @@ secure-cookie: {{ .Env.SECURE_COOKIE }}
 
 skip-openid-provider-tls-verify: true
 
-enable-refresh-tokens: false
+enable-refresh-tokens: true
 # the name of the refresh cookie, default to kc-state
 cookie-refresh-name: havengrc-state
 # the encryption key used to encode the session state


### PR DESCRIPTION
With this enabled gatekeeper will inject the
new access token into the request so the user
does not need to do a full page refresh anymore.

Issue #HAV-15

Signed-off-by: Christopher Mundus <chris@kindlyops.com>
