### PR TITLE
Fix for allowing blank and completely bogus emails

### DIFF
--- a/apitest/features/sqitch-nojwt.feature
+++ b/apitest/features/sqitch-nojwt.feature
@@ -50,3 +50,13 @@ Feature: Basic sqitch access control
         When I send a DELETE request to "http://{api_server}/ipsative_surveys"
         Then the response status should be "401"
 
+    Scenario: Save registration with invalid email address
+        When I set JSON request body to:
+        """
+        {
+        "email": "_@_",
+        "survey_results": []
+        }
+        """
+        And  I send a POST request to "http://{buffalo_server}/api/registration_funnel"
+        Then the response status should be "422"

--- a/keycloak-service-providers/magic-link/src/main/resources/theme-resources/templates/login-email-only.ftl
+++ b/keycloak-service-providers/magic-link/src/main/resources/theme-resources/templates/login-email-only.ftl
@@ -13,7 +13,7 @@
                     </div>
 
                     <div class="${properties.kcInputWrapperClass!}">
-                        <input tabindex="1" id="email" class="${properties.kcInputClass!}" name="email"  type="text" autofocus autocomplete="off" />
+                        <input tabindex="1" id="email" class="${properties.kcInputClass!}" name="email" type="email" required autofocus autocomplete="off" />
                     </div>
                 </div>
 

--- a/webui/src/Page/Survey.elm
+++ b/webui/src/Page/Survey.elm
@@ -1214,36 +1214,6 @@ viewFinished model =
         ]
 
 
-viewRegistrationError : Model -> Html Msg
-viewRegistrationError model =
-    div [ class "d-flex flex-column" ]
-        [ img [ class "img-fluid mt-3", alt "Haven GRC Company Logo", attribute "data-rjs" "2", id "logo", src "/img/logo@2x.png", height 71, width 82 ] []
-        , div [ class "row" ]
-            [ div [ class "col-xs-12 text-center mt-5" ]
-                [ h1 [ class "survey-heading mb-5" ] [ text "You finished the survey!" ]
-                , div [ class "vis", id "vis" ] []
-                , div [ class "col-md-8 mx-auto my-5" ]
-                    [ p [] [ text "Do you want a shareable version of these results? Enter your email and we will generate a customized powerpoint presentation that includes these results so that you can incorporate them into your own presentation." ]
-                    , p []
-                        [ text "By submitting your email you agree to our "
-                        , a [ href "/terms", target "_blank", rel "noopener noreferrer" ] [ text "Terms of Service" ]
-                        , text " and "
-                        , a [ href "/privacy", target "_blank", rel "noopener noreferrer" ] [ text "Privacy Policy" ]
-                        , text "."
-                        ]
-                    , div [ class "col-md-7 mx-auto mt-5" ]
-                        [ div [ class "input-group" ]
-                            [ input [ type_ "email", required True, placeholder "Email Address", class "form-control", value model.emailAddress, onInput UpdateEmail ] []
-                            , i [ class "material-icons", style "color" "rgba(0, 0, 0, 0.42)" ] [ text "chevron_right" ]
-                            ]
-                        ]
-                    ]
-                , button [ class "btn btn-primary", onClick RegisterNewUser, disabled <| isValidEmail model.emailAddress ] [ text "Click to save results to the server" ]
-                ]
-            ]
-        ]
-
-
 viewRegistration : Model -> Html Msg
 viewRegistration model =
     div [ class "d-flex flex-column" ]

--- a/webui/src/Utils.elm
+++ b/webui/src/Utils.elm
@@ -20,7 +20,16 @@ getHTTPErrorMessage error =
             "Is the server running?"
 
         Http.BadStatus code ->
-            "Bad status reponse " ++ String.fromInt code
+            let
+                -- 422 Unprocessable Entity
+                stringResponse =
+                    if code == 422 then
+                        "Please use a valid email address."
+
+                    else
+                        "Bad status reponse " ++ String.fromInt code
+            in
+            stringResponse
 
         Http.BadBody message ->
             "Decoding Failed: " ++ message


### PR DESCRIPTION
Issue #HAV-310

Signed-off-by: Christopher Mundus <chris@kindlyops.com>

# Description

Added html5 email verification in the magic link section but since we are not using an actual form for the registration page we will do a simple regex to look for non whitespace before and after an @ symbol which will then allow the user to click the send button.

We also validate in go and return a 422 status code if we do not receive a proper email. 

Magiclink:
<img width="448" alt="Screen Shot 2019-08-06 at 12 13 53 PM" src="https://user-images.githubusercontent.com/17323411/62557224-8dee4380-b844-11e9-8d27-a5cf11ee8da7.png">
<img width="328" alt="Screen Shot 2019-08-06 at 12 13 41 PM" src="https://user-images.githubusercontent.com/17323411/62557225-8dee4380-b844-11e9-835a-8af9db7fe052.png">

Registration:
<img width="703" alt="Screen Shot 2019-08-06 at 12 21 01 PM" src="https://user-images.githubusercontent.com/17323411/62557346-cee65800-b844-11e9-94c6-6daba3770bc2.png">
<img width="762" alt="Screen Shot 2019-08-06 at 12 20 51 PM" src="https://user-images.githubusercontent.com/17323411/62557347-cee65800-b844-11e9-8242-4b4d31ee7567.png">
