### PR TITLE
Fix for magiclink bug

### DIFF
--- a/keycloak/themes/haven/login/login.ftl
+++ b/keycloak/themes/haven/login/login.ftl
@@ -58,7 +58,7 @@
                             <p class="mb-1"><a href="${p.loginUrl}" id="zocial-${p.alias}" class="zocial ${p.providerId}"> <span class="text">${p.displayName}</span></a></p>
                         </#list>
                         <list>
-                            <p class="mb-1"><a id="zocial-magic-link" class="zocial magic-link" href="/auth/realms/${realm.name}/protocol/openid-connect/auth?client_id=magic-link&response_mode=fragment&response_type=code&login=true&redirect_uri=%2Fdashboard"> <span class="text">Email me a sign-in link</span></a></p>
+                            <p class="mb-1"><a id="zocial-magic-link" class="zocial magic-link" href="/auth/realms/${realm.name}/protocol/openid-connect/auth?client_id=magic-link&response_mode=fragment&response_type=code&login=true&redirect_uri=%2Foauth%2Fauthorize"> <span class="text">Email me a sign-in link</span></a></p>
                         </list>
                 </div>
             </#if>


### PR DESCRIPTION
Issue #HAV-319

Signed-off-by: Christopher Mundus <chris@kindlyops.com>

# Description

Magiclink was failing due to a dead end url
