### PR TITLE
Better cypress test

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,14 @@ To get the content-disposition header set with the filename prefilled:
 
 You can decode the token to inspect the contents at jwt.io. You will need to get the public cert from the Keycloak Admin interface: Havendev-\>Realm Settings-\>Keys-\>Public Key and enter it into the jwt.io page to decode the token.
 
+### Low level network debugging
+
+To inspect network traffic received by Keycloak for debugging complex network
+proxy issues, you can exec a shell inside the keycloak container and run ngrep.
+
+    docker exec -u 0 -it keycloak bash
+    ngrep -q -W byline port 8080
+
 ## Learning Elm
 
 16 minute video by Richard Feldman that explains the framework architecture choices that Elm makes compared to jQuery and Flux. [From jQuery to Flux to Elm](https://www.youtube.com/watch?v=NgwQHGqIMbw).

--- a/apitest/Dockerfile
+++ b/apitest/Dockerfile
@@ -5,9 +5,9 @@ RUN bundle config --global frozen 1
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-COPY ./apitest/Gemfile /usr/src/app
-COPY ./apitest/Gemfile.lock /usr/src/app
-COPY ./apitest/features/ /usr/src/app/features
-COPY ./apitest/vendor /usr/src/app/vendor
+COPY ./Gemfile /usr/src/app
+COPY ./Gemfile.lock /usr/src/app
+COPY ./features/ /usr/src/app/features
+COPY ./vendor /usr/src/app/vendor
 RUN bundle install --local
 CMD ["cucumber"]

--- a/docker-compose.admin.yml
+++ b/docker-compose.admin.yml
@@ -56,7 +56,7 @@ services:
       - ./mailhog/maildir:/maildir
   apitest:
     build:
-      context: .
+      context: ./apitest
       dockerfile: ./apitest/Dockerfile
     working_dir: /usr/src/app
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,7 @@ services:
       - KC_PORT=8080
       - FAKTORY_URL=tcp://:fassword@faktory:7419
     build:
-      context: .
+      context: ./havenapi
       dockerfile: ./havenapi/Dockerfile-hotreload
     links:
       - db
@@ -188,5 +188,3 @@ services:
     command: [/code/installrun.sh]
     environment:
       - ELM_APP_KEYCLOAK_CLIENT_ID=havendev
-      - VIRTUAL_HOST=dev.havengrc.com
-

--- a/e2e-tests-cleanup.sh
+++ b/e2e-tests-cleanup.sh
@@ -26,6 +26,9 @@ docker rm cucumber
 docker stop gatekeeper
 docker rm gatekeeper
 
+docker stop webui
+docker rm webui
+
 docker rm cypress
 
 docker stop db

--- a/e2e-tests.sh
+++ b/e2e-tests.sh
@@ -15,26 +15,29 @@ export PGRST_JWT_AUD_CLAIM=havendev
 export PGRST_SERVER_PROXY_URI=http://api:8180
 export KEYCLOAK_USER=admin
 export KEYCLOAK_PASSWORD=admin
-export PROXY_ADDRESS_FORWARDING="true"
+export PROXY_ADDRESS_FORWARDING=true
+export KEYCLOAK_INTERNAL=http://keycloak:8080
+export KEYCLOAK_SCHEME=http
+export KEYCLOAK_HOSTNAME=dev.havengrc.com
+export KEYCLOAK_HTTP_PORT=80
+export KEYCLOAK_HTTPS_PORT=443
 export FLYWAY_URL="jdbc:postgresql://db/mappamundi_dev"
 export FLYWAY_USER=circleci
 export FLYWAY_IGNORE_MISSING_MIGRATIONS="true"
 export FLYWAY_GROUP="true"
 export FLYWAY_SCHEMAS=mappa,1
 export HAVEN_JWK_PATH=/cfg/keycloak-dev-public-key.json
-export HAVEN_JWT_ISS=http://keycloak:8080/auth/realms/havendev
+export HAVEN_JWT_ISS=http://dev.havengrc.com/auth/realms/havendev
 export TEST_DATABASE_URL="postgres://circleci@db:5432/mappamundi_test?sslmode=disable"
 export API_SERVER=api:8180
-export AUTH_SERVER=keycloak:8080
-export BUFFALO_SERVER=havenapi:3000
+export AUTH_SERVER=dev.havengrc.com
+export BUFFALO_SERVER=dev.havengrc.com
 export DISCOVERY_URL=http://webui/auth/realms/havendev
 export UPSTREAM_URL=http://webui/
-export GATEKEEPER_SESSION_KEY="c01f3736e640ea874d66c3704ddb7a9a"
-export SECURE_COOKIE="false"
-export GATEKEEPER_LISTEN_PORT="81"
+export GATEKEEPER_SESSION_KEY=c01f3736e640ea874d66c3704ddb7a9a
+export SECURE_COOKIE=false
+export GATEKEEPER_LISTEN_PORT=81
 export REDIRECTION_URL=http://dev.havengrc.com/
-export KEYCLOAK_INTERNAL=http://keycloak:8080
-export KEYCLOAK_SCHEME=http
 export DISCOVERY_URL=http://dev.havengrc.com/auth/realms/havendev
 export BASE_URI=""
 export GATEKEEPER_INTERNAL=http://gatekeeper:81
@@ -62,7 +65,7 @@ docker cp postgrest/keycloak-dev-public-key.json configs:/cfg
 docker cp keycloak/data/havendev-realm.json configs:/keycloak
 docker pull kindlyops/keycloak:$KEYCLOAK_REV
 # start keycloak in background container
-docker run --volumes-from configs --network net0 -d -e DB_DATABASE -e DB_USER -e DB_ADDR -e KEYCLOAK_USER -e KEYCLOAK_PASSWORD -e PROXY_ADDRESS_FORWARDING -h keycloak --name keycloak kindlyops/keycloak:$KEYCLOAK_REV -b 0.0.0.0 -Dkeycloak.migration.file=/keycloak/havendev-realm.json -Dkeycloak.migration.strategy=IGNORE_EXISTING -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.action=import
+docker run --volumes-from configs --network net0 -d -e DB_DATABASE -e DB_USER -e DB_ADDR -e KEYCLOAK_USER -e KEYCLOAK_PASSWORD -e PROXY_ADDRESS_FORWARDING -e KEYCLOAK_HTTP_PORT -e KEYCLOAK_HTTPS_PORT -e KEYCLOAK_HOSTNAME -h keycloak --name keycloak kindlyops/keycloak:$KEYCLOAK_REV -b 0.0.0.0 -Dkeycloak.migration.file=/keycloak/havendev-realm.json -Dkeycloak.migration.strategy=IGNORE_EXISTING -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.action=import
 # Wait for keycloak
 docker run --network net0 --name dockerize3 jwilder/dockerize  -wait tcp://keycloak:8080 -timeout 2m
 docker pull kindlyops/havenflyway:$FLYWAY_REV
@@ -75,7 +78,6 @@ docker run --network net0 --name dockerize4 jwilder/dockerize  -wait tcp://api:8
 docker run --volumes-from configs --network net0 --name buffalotest -e KC_ADMIN=admin -e KC_PW=admin -e KC_HOST=http://keycloak -e KC_PORT=8080 -e TEST_DATABASE_URL -e HAVEN_JWK_PATH -e HAVEN_JWT_ISS kindlyops/havenapitest /go/bin/buffalo test
 docker run --volumes-from configs --network net0 -d -h havenapi --name havenapi -e KC_ADMIN=admin -e KC_PW=admin -e KC_HOST=http://keycloak -e KC_PORT=8080 -e TEST_DATABASE_URL -e HAVEN_JWK_PATH -e HAVEN_JWT_ISS kindlyops/havenapitest /go/bin/buffalo dev
 docker run --network net0 --name dockerize5 jwilder/dockerize  -wait tcp://havenapi:3000 -timeout 2m
-docker run --volumes-from configs --name cucumber --network net0 -e API_SERVER -e AUTH_SERVER -e BUFFALO_SERVER --workdir /usr/src/app kindlyops/apitest cucumber
 echo $WEBUI_TEST_CERT|base64 --decode - > fullchain.pem
 echo $WEBUI_TEST_KEY|base64 --decode - > privkey.pem
 # creating dummy container which will hold a volume with certs
@@ -86,9 +88,15 @@ docker cp privkey.pem certs:/certs
 rm privkey.pem
 docker pull kindlyops/havenweb:$WEBUI_REV
 docker run -d --volumes-from certs --network net0 -h webui --name webui -e ELM_APP_KEYCLOAK_CLIENT_ID=havendev kindlyops/havenweb:$WEBUI_REV
+docker run --volumes-from configs --name cucumber --network net0 --link="webui:dev.havengrc.com" -e API_SERVER -e AUTH_SERVER -e BUFFALO_SERVER --workdir /usr/src/app kindlyops/apitest cucumber --backtrace
 docker pull kindlyops/gatekeeper:$GATEKEEPER_REV
-docker run -d --volumes-from certs --network net0 --publish 80:81 --name gatekeeper -e DISCOVERY_URL -e UPSTREAM_URL -e REDIRECTION_URL -e GATEKEEPER_LISTEN_PORT -e SECURE_COOKIE -e GATEKEEPER_SESSION_KEY -e KEYCLOAK_INTERNAL -e KEYCLOAK_SCHEME -e DISCOVERY_URL -e BASE_URI -e CLIENT_SECRET kindlyops/gatekeeper:$GATEKEEPER_REV
+docker run -d --volumes-from certs --network net0 --publish 80:81 --name gatekeeper -e DISCOVERY_URL -e UPSTREAM_URL -e REDIRECTION_URL -e GATEKEEPER_LISTEN_PORT -e SECURE_COOKIE -e GATEKEEPER_SESSION_KEY -e KEYCLOAK_INTERNAL -e KEYCLOAK_SCHEME -e DISCOVERY_URL -e BASE_URI -e CLIENT_SECRET --add-host dev.havengrc.com:127.0.0.1 kindlyops/gatekeeper:$GATEKEEPER_REV
 docker build -t kindlyops/cypress -f webui/Dockerfile-cypress ./webui
 # creating dummy container to hold volume with outputs from cypress
 docker create -v /e2e/cypress/videos/ --name videos alpine:3.4 /bin/true
+
+# useful when pausing for running ngrep inside some of the containers under test
+# for manual debbugging
+# read -rsp $'Press any key to continue...\n' -n1 key
+
 docker run --network net0 --name cypress -e GATEKEEPER_INTERNAL --volumes-from videos kindlyops/cypress run

--- a/e2e-tests.sh
+++ b/e2e-tests.sh
@@ -67,9 +67,9 @@ docker run --volumes-from configs --network net0 -d -e DB_DATABASE -e DB_USER -e
 docker run --network net0 --name dockerize3 jwilder/dockerize  -wait tcp://keycloak:8080 -timeout 2m
 docker pull kindlyops/havenflyway:$FLYWAY_REV
 docker run --network net0 --name flyway -e FLYWAY_URL -e FLYWAY_USER -e FLYWAY_IGNORE_MISSING_MIGRATIONS -e FLYWAY_GROUP -e FLYWAY_SCHEMAS kindlyops/havenflyway:$FLYWAY_REV migrate -placeholders.databaseUser=circleci
-docker build -t kindlyops/havenapitest -f havenapi/Dockerfile-hotreload .
+docker build -t kindlyops/havenapitest -f havenapi/Dockerfile-hotreload ./havenapi
 docker pull kindlyops/havenapi:$HAVENAPI_REV
-docker build -t kindlyops/apitest -f apitest/Dockerfile .
+docker build -t kindlyops/apitest -f apitest/Dockerfile ./apitest
 docker run -d --volumes-from configs --network net0 -h api --name api -e DATABASE_USERNAME -e DATABASE_PASSWORD -e DATABASE_HOST -e HAVEN_JWK_PATH -e PGRST_JWT_AUD_CLAIM -e PGRST_SERVER_PROXY_URI kindlyops/postgrest postgrest config
 docker run --network net0 --name dockerize4 jwilder/dockerize  -wait tcp://api:8180 -timeout 2m
 docker run --volumes-from configs --network net0 --name buffalotest -e KC_ADMIN=admin -e KC_PW=admin -e KC_HOST=http://keycloak -e KC_PORT=8080 -e TEST_DATABASE_URL -e HAVEN_JWK_PATH -e HAVEN_JWT_ISS kindlyops/havenapitest /go/bin/buffalo test

--- a/havenapi/Dockerfile-hotreload
+++ b/havenapi/Dockerfile-hotreload
@@ -2,7 +2,7 @@ FROM gobuffalo/buffalo:v0.14.3
 
 RUN mkdir -p $GOPATH/src/github.com/kindlyops/havengrc/havenapi
 WORKDIR $GOPATH/src/github.com/kindlyops/havengrc/havenapi
-ADD ./havenapi/ $GOPATH/src/github.com/kindlyops/havengrc/havenapi
+ADD ./ $GOPATH/src/github.com/kindlyops/havengrc/havenapi
 
 EXPOSE 3000
 ENV ADDR 0.0.0.0

--- a/webui/cypress/Caddyfile.tmpl
+++ b/webui/cypress/Caddyfile.tmpl
@@ -4,7 +4,8 @@ proxy / {{ .Env.GATEKEEPER_INTERNAL }} {
     header_upstream Host {host}
     header_upstream X-Real-IP {remote}
     header_upstream X-Forwarded-For {remote}
+    header_upstream X-Forwarded-Proto {scheme}
 }
 
-log / stdout "{combined}"
-errors stdout
+log / /tmp/caddy.log "{combined}"
+errors /tmp/caddy.err

--- a/webui/cypress/integration/login_spec.js
+++ b/webui/cypress/integration/login_spec.js
@@ -3,5 +3,7 @@ describe('Login to application', function () {
         cy.visit('/')
         cy.contains('Login').click()
         cy.url().should('include', '/auth/realms/havendev/protocol/openid-connect')
+        cy.contains('Log In With')
+            .should('be.visible')
     })
 })


### PR DESCRIPTION
# Description

Working on fixing the cypress e2e test, they were incorrectly reporting as passing before.

loading the login page is giving a 400 error, and the error in the keycloak logs is

```
01:47:46,595 WARN  [org.jboss.resteasy.resteasy_jaxrs.i18n] (default task-1) RESTEASY002130: Failed to parse request.: java.lang.IllegalArgumentException: RESTEASY003415: Illegal uri template: ://dev.havengrc.com:80/auth/realms/havendev/protocol/openid-connect/auth
        at org.jboss.resteasy.specimpl.R
```