### PR TITLE
K8s sentry, fixes HAV-264

### DIFF
--- a/k8s/failpod.yaml
+++ b/k8s/failpod.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-slack-test
+spec:
+  containers:
+  - image: willwill/inexisting
+    name: kube-slack-test
+  resources:
+    limits:
+      memory: 32Mi
+    requests:
+      memory: 32Mi

--- a/k8s/gatekeeper-deployment.yaml
+++ b/k8s/gatekeeper-deployment.yaml
@@ -73,9 +73,9 @@ spec:
               successThreshold: 1
           resources:
             limits:
-              memory: 256Mi
-            requests:
               memory: 128Mi
+            requests:
+              memory: 64Mi
       volumes:
         - name: secret-volume
           secret:

--- a/k8s/havenapi-deployment.yaml
+++ b/k8s/havenapi-deployment.yaml
@@ -64,6 +64,11 @@ spec:
                 secretKeyRef:
                   name: sentry
                   key: dsn
+            - name: SLACK_WEBHOOK
+              valueFrom:
+                secretKeyRef:
+                  name: slack
+                  key: webhook
           volumeMounts:
             - name: secret-volume
               mountPath: /etc/haven-credentials/

--- a/k8s/havenweb-deployment.yaml
+++ b/k8s/havenweb-deployment.yaml
@@ -39,7 +39,7 @@ spec:
               readOnly: true
           resources:
               limits:
-                memory: 256Mi
+                memory: 128Mi
               requests:
                 memory: 128Mi
       volumes:

--- a/k8s/kube-slack-deployment.yaml
+++ b/k8s/kube-slack-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-slack
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      name: kube-slack
+      labels:
+        app: kube-slack
+    spec:
+      serviceAccountName: kube-slack
+      containers:
+      - name: kube-slack
+        image: willwill/kube-slack:v4.2.0
+        env:
+        - name: SLACK_URL
+          valueFrom:
+            secretKeyRef:
+              name: slack
+              key: webhook
+        - name: SLACK_USERNAME
+          value: 'kube-slack-bot'
+        - name: SLACK_CHANNEL
+          value: 'notifications'
+        - name: KUBE_NAMESPACES_ONLY
+          value: "haven-production"
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            memory: 64Mi
+            cpu: 5m
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - key: CriticalAddonsOnly
+        operator: Exists

--- a/k8s/kube-slack-roles.yaml
+++ b/k8s/kube-slack-roles.yaml
@@ -1,0 +1,28 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-slack
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-slack
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-slack
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-slack
+subjects:
+  - kind: ServiceAccount
+    name: kube-slack
+    namespace: kube-system

--- a/k8s/sentry-deployment.yaml
+++ b/k8s/sentry-deployment.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: sentry
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 50%
+  template:
+    metadata:
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
+      labels:
+        service: sentry
+    spec:
+      containers:
+        - name: sentry
+          image: getsentry/sentry-kubernetes:latest
+          env:
+            - name: ENV
+              value: "production"
+            - name: DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry
+                  key: dsn
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              memory: 128Mi
+      restartPolicy: Always
+  strategy:
+    type: "Recreate"
+  paused: false
+  revisionHistoryLimit: 2
+  minReadySeconds: 0
+status: {}

--- a/k8s/worker-deployment.yaml
+++ b/k8s/worker-deployment.yaml
@@ -15,6 +15,11 @@ spec:
       containers:
         - name: worker
           image: kindlyops/havenworker
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 128Mi
           env:
             - name: DATABASE_NAME
               value: "havenstage"


### PR DESCRIPTION
# Description

got kube-slack working on openshift to yell at us when pods start failing after a deploy