### PR TITLE
Fix for listing only users reports

### DIFF
--- a/apitest/features/sqitch-files.feature
+++ b/apitest/features/sqitch-files.feature
@@ -26,3 +26,18 @@ Feature: Basic sqitch API interaction with file storage
         And the JSON response root should be object
         And the JSON response should have "$.message" of type string and value "success"
 
+    Scenario: Test uploading to new reports API with another user
+        When I set form request body to:
+        | name | minimal.pdf                 |
+        | file | file://features/minimal.pdf |
+        And I sign in to keycloak with "test@test.com" and "password"
+        And I send a POST request to "http://{buffalo_server}/api/reports"
+        Then the response status should be "200"
+        And the JSON response root should be object
+        And the JSON response should have "$.message" of type string and value "success"
+
+    Scenario: Make sure the files are for the first user only
+        When I send a GET request to "http://{buffalo_server}/api/files"
+        Then the response status should be "200"
+        And the JSON response root should be array
+        Then all "user_id" fields should be of type string and value "90920d91-3090-4b4a-ae2a-2377cfa06ecd"

--- a/havenapi/models/file.go
+++ b/havenapi/models/file.go
@@ -16,7 +16,7 @@ type File struct {
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	UserID    uuid.UUID `json:"user_id" db:"user_id"`
 	Name      string    `json:"name" db:"name"`
-	File      []byte    	`json:"file" db:"file"`
+	File      []byte    `json:"file" db:"file"`
 }
 
 // FileInfo is the survey data file info
@@ -26,11 +26,13 @@ type FileInfo struct {
 	UserID    uuid.UUID `json:"user_id" db:"user_id"`
 	Name      string    `json:"name" db:"name"`
 }
+
 // TableName overrides the schema and table name
 func (FileInfo) TableName() string {
 	// schema.table_name
-	return "mappa.files"
+	return "files"
 }
+
 // String is not required by pop and may be deleted
 func (f FileInfo) String() string {
 	jf, _ := json.Marshal(f)


### PR DESCRIPTION
Fix needed for listing only the current users reports.

Notable changes found on line 73 of havenapi/actions/reports.go to use the view instead.

Some linting changes as well.

Issue #HAV-333

Signed-off-by: Christopher Mundus <chris@kindlyops.com>

