### PR TITLE
Fix for corrupt downloads

### DIFF
--- a/havenapi/actions/reports.go
+++ b/havenapi/actions/reports.go
@@ -40,9 +40,13 @@ func UploadHandler(c buffalo.Context) error {
 // DownloadHandler downloads a report
 func DownloadHandler(c buffalo.Context) error {
 	tx := c.Value("tx").(*pop.Connection)
+	err := tx.RawQuery("set local search_path to 1").Exec()
+	if err != nil {
+		return c.Error(500, fmt.Errorf("Database error: %s", err.Error()))
+	}
 
 	file := models.File{}
-	err := tx.Find(&file, c.Param("file_id"))
+	err = tx.Find(&file, c.Param("file_id"))
 	if err != nil {
 		return c.Error(500, fmt.Errorf("error retrieving file from database: %s", err.Error()))
 	}


### PR DESCRIPTION
Downloads were blank due to not using the correct db search path. Also adding some more error handlers and removed the space in the time string for file naming to prevent any issues passing it to the compile report script.

Issue #HAV-334
Signed-off-by: Christopher Mundus <chris@kindlyops.com>
